### PR TITLE
Rcon via file

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -68,6 +68,7 @@ echo "Completed post install configuration."
 ## create cfg file for parameter options, stops rcon in ps aux
 
 cfgpath="${STEAMAPPDIR}/${STEAMAPP}/cfg/"
+mkdir "$cfgpath/commandline/"
 cat > "$cfgpath/commandline/autoexec.cfg" << EOL
 +sv_lan "${SRCDS_LAN}" 
 fps_max "${SRCDS_FPSMAX}"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -67,7 +67,7 @@ echo "Completed post install configuration."
 
 ## create cfg file for parameter options, stops rcon in ps aux
 
-cfgpath=""${STEAMAPPDIR}/${STEAMAPP}/cfg/"
+cfgpath="${STEAMAPPDIR}/${STEAMAPP}/cfg/"
 cat > "$cfgpath/commandline/autoexec.cfg" << EOL
 +sv_lan "${SRCDS_LAN}" 
 fps_max "${SRCDS_FPSMAX}"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -65,20 +65,27 @@ fi
 
 echo "Completed post install configuration."
 
+## create cfg file for parameter options, stops rcon in ps aux
+
+cfgpath=""${STEAMAPPDIR}/${STEAMAPP}/cfg/"
+cat > "$cfgpath/commandline/autoexec.cfg" << EOL
++sv_lan "${SRCDS_LAN}" 
+fps_max "${SRCDS_FPSMAX}"
+maxplayers "${SRCDS_MAXPLAYERS}"
++sv_setsteamaccount "${SRCDS_TOKEN}"
++rcon_password "$RCON_PASSWORD"
++sv_password "${SRCDS_PW}"
++sv_region "${SRCDS_REGION}"
+EOL
+
 # If no autoexec is present, use all parameters
 bash "${STEAMAPPDIR}/srcds_run" -game "${STEAMAPP}" -console -autoupdate \
             -steam_dir "${STEAMCMDDIR}" \
             -steamcmd_script "${HOMEDIR}/${STEAMAPP}_update.txt" \
             -usercon \
-            +fps_max "${SRCDS_FPSMAX}" \
             -port "${SRCDS_PORT}" \
-            +maxplayers "${SRCDS_MAXPLAYERS}" \
             +map "$SRCDS_STARTMAP" \
-            +sv_setsteamaccount "${SRCDS_TOKEN}" \
-            +rcon_password "$RCON_PASSWORD" \
-            +sv_password "${SRCDS_PW}" \
-            +sv_region "${SRCDS_REGION}" \
             +net_public_adr "$publicaddress" \
-            +sv_lan "${SRCDS_LAN}" \
+            +exec "commandline/autoexec.cfg" \
             +exec "${SRCDS_AUTOEXEC}" \
             "${ADDITIONAL_ARGS}"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -68,15 +68,18 @@ echo "Completed post install configuration."
 ## create cfg file for parameter options, stops rcon in ps aux
 
 cfgpath="${STEAMAPPDIR}/${STEAMAPP}/cfg/"
-mkdir "$cfgpath/commandline/"
-cat > "$cfgpath/commandline/autoexec.cfg" << EOL
-+sv_lan "${SRCDS_LAN}" 
-fps_max "${SRCDS_FPSMAX}"
-maxplayers "${SRCDS_MAXPLAYERS}"
-+sv_setsteamaccount "${SRCDS_TOKEN}"
-+rcon_password "$RCON_PASSWORD"
-+sv_password "${SRCDS_PW}"
-+sv_region "${SRCDS_REGION}"
+mkdir "$cfgpath/"
+cat > "$cfgpath/commandline.cfg" << EOL
+sv_lan ${SRCDS_LAN}
+fps_max ${SRCDS_FPSMAX}
+maxplayers ${SRCDS_MAXPLAYERS}
+sv_setsteamaccount ${SRCDS_TOKEN}
+rcon_password "$RCON_PASSWORD"
+sv_password "${SRCDS_PW}"
+sv_region ${SRCDS_REGION}
+
+// run requested auto exec
+exec ${SRCDS_AUTOEXEC}
 EOL
 
 # If no autoexec is present, use all parameters
@@ -87,6 +90,5 @@ bash "${STEAMAPPDIR}/srcds_run" -game "${STEAMAPP}" -console -autoupdate \
             -port "${SRCDS_PORT}" \
             +map "$SRCDS_STARTMAP" \
             +net_public_adr "$publicaddress" \
-            +exec "commandline/autoexec.cfg" \
-            +exec "${SRCDS_AUTOEXEC}" \
+            +exec "commandline.cfg" \
             "${ADDITIONAL_ARGS}"


### PR DESCRIPTION
Use a file for command line options instead of command line. Users on the docker host can read process list which would allow them to see the rcon password or server password. Also makes the command list shorter and clear.